### PR TITLE
Add Super Bunny Cave access

### DIFF
--- a/js/doors.js
+++ b/js/doors.js
@@ -1094,6 +1094,7 @@ window.doorLocations = {
   },
   'DW East DM Upper Exit': {
     region: 'Dark World Death Mountain',
+    cave: 'Super Bunny Cave',
     tag: 'dw',
     x: '86.53%',
     y: '6.56%',


### PR DESCRIPTION
Super Bunny Cave should be accessible from both DW East DM Upper Exit & DW Twin Cave Left, bidirectional.