### PR TITLE
fix the mushroom in item randomizer

### DIFF
--- a/js/item_randomizer.js
+++ b/js/item_randomizer.js
@@ -563,7 +563,7 @@ window.item_randomizer = {
       "Witch's Hut": {
         x: '82.65%',
         y: '31.90%',
-        state() {
+        state(items) {
           return items.has('mushroom') ? 'available' : '';
         },
       },


### PR DESCRIPTION
This caused quite a few locations to disappear because "items" was not found by the javascript interpretor.